### PR TITLE
Feature: Export csv

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tiptap/starter-kit": "^2.0.3",
     "axios": "^1.3.4",
     "dayjs": "^1.11.8",
+    "export-to-csv": "^0.2.1",
     "firebase": "^9.18.0",
     "mantine-react-table": "^1.0.0-beta.8",
     "path": "^0.12.7",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -38,6 +38,11 @@ export const pretyDateTime = (date: Date) => {
   });
 };
 
+export const yyyymmddDateFormater = (date: Date) => {
+  const dt = new Date(date);
+  return dt.toISOString().slice(0, 10).replace(/-/g, "");
+};
+
 export const formatSize = (bytes: number) => {
   if (bytes < 1024) {
     return bytes + " B";
@@ -93,4 +98,15 @@ export const isMeetingLink = (string?: string): boolean => {
     string.includes(service)
   );
   return isMeetingService && !isMapsService;
+};
+
+export const mergeObjects = <T extends object>(
+  arr: T[]
+): Record<keyof T, any> => {
+  return arr.reduce((result, obj) => {
+    Object.keys(obj).forEach((key) => {
+      result[key as keyof T] = obj[key as keyof T];
+    });
+    return result;
+  }, {} as Record<keyof T, any>);
 };

--- a/src/modules/trainings/pages/manageTrainings/applicants.tsx
+++ b/src/modules/trainings/pages/manageTrainings/applicants.tsx
@@ -22,6 +22,7 @@ import { MRT_ColumnDef, MantineReactTable } from "mantine-react-table";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
 
+const firestorageBucket = import.meta.env.VITE_FIREBASE_STORAGE_BUCKET;
 export const ManageTrainingApplicants = () => {
   const theme = useMantineTheme();
   const isMobile = useMediaQuery(
@@ -293,6 +294,9 @@ export const ManageTrainingApplicants = () => {
         enableTopToolbar={true}
         mantineTopToolbarProps={{ display: "none" }}
         renderTopToolbarCustomActions={({ table }) => {
+          const fileUrlParser = (filename: string) =>
+            `https://firebasestorage.googleapis.com/v0/b/${firestorageBucket}/o/temp%2F${filename}?alt=media`;
+
           const dataFlatter = (rows: TrainingMember[]) =>
             rows.map((row, i) => {
               const dt = {
@@ -308,13 +312,13 @@ export const ManageTrainingApplicants = () => {
                 requiredFiles: row.requiredFiles.length,
                 ...mergeObjects(
                   row.requiredFiles.map((data) => ({
-                    [data.tag]: data.filename,
+                    [data.tag]: fileUrlParser(data.filename),
                   }))
                 ),
                 issuedCertificate: row.issuedCertificate.length,
                 ...mergeObjects(
                   row.issuedCertificate.map((data) => ({
-                    [data.tag]: data.filename,
+                    [data.tag]: fileUrlParser(data.filename),
                   }))
                 ),
               } as Record<keyof TrainingMember, any>;

--- a/src/modules/trainings/pages/manageTrainings/applicants.tsx
+++ b/src/modules/trainings/pages/manageTrainings/applicants.tsx
@@ -295,7 +295,9 @@ export const ManageTrainingApplicants = () => {
         mantineTopToolbarProps={{ display: "none" }}
         renderTopToolbarCustomActions={({ table }) => {
           const fileUrlParser = (filename: string) =>
-            `https://firebasestorage.googleapis.com/v0/b/${firestorageBucket}/o/temp%2F${filename}?alt=media`;
+            new URL(
+              `https://firebasestorage.googleapis.com/v0/b/${firestorageBucket}/o/temp%2F${filename}?alt=media`
+            ).toString();
 
           const dataFlatter = (rows: TrainingMember[]) =>
             rows.map((row, i) => {

--- a/src/ui/Button/ExportMenu.tsx
+++ b/src/ui/Button/ExportMenu.tsx
@@ -1,0 +1,128 @@
+import { ActionIcon, Button, Flex, Menu, useMantineTheme } from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+import { ExportToCsv, Options } from "export-to-csv";
+import { IconSave } from "../Icons";
+import { yyyymmddDateFormater } from "@/lib/utils";
+
+// Constants for configuration
+const today = new Date(Date.now());
+const csvOptions = (filename?: string): Options => ({
+  fieldSeparator: ",",
+  quoteStrings: '"',
+  decimalSeparator: ".",
+  showLabels: true,
+  useBom: true,
+  useKeysAsHeaders: true,
+  filename: `${yyyymmddDateFormater(today)}-seetrum-${
+    filename || "generatedData"
+  }`,
+});
+
+// Types and interfaces
+type Exporter = <T extends object>(data: T[]) => void;
+
+interface ExportMenuProps {
+  exportAllRef: React.RefObject<HTMLButtonElement>;
+  exportRowsRef: React.RefObject<HTMLButtonElement>;
+}
+
+interface TablePseudoExportButtonProps {
+  exportAllRef: React.RefObject<HTMLButtonElement>;
+  exportRowsRef: React.RefObject<HTMLButtonElement>;
+  onExportAll: (exporter: Exporter) => void;
+  onExportRows: (exporter: Exporter) => void;
+  filenames?: string;
+}
+
+// Components
+/**
+ * ExportMenu Button that will display menu options for exporting data
+ * @example
+ * <ExportMenu
+ *   exportAllRef={buttonRef}
+ *   exportRowsRef={button2Ref}
+ * />
+ */
+export const ExportMenu = ({
+  exportAllRef,
+  exportRowsRef,
+}: ExportMenuProps) => {
+  const t = useMantineTheme();
+  const isMobile = useMediaQuery(t.fn.smallerThan("sm").replace("@media ", ""));
+
+  return (
+    <Menu shadow="md" width={200} position="bottom-end">
+      <Menu.Target>
+        {isMobile ? (
+          <ActionIcon variant="filled" radius={8} color="primary" size={32}>
+            <IconSave size={12} />
+          </ActionIcon>
+        ) : (
+          <Button leftIcon={<IconSave size={14} />} radius={8}>
+            Export data{" "}
+          </Button>
+        )}
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Item
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (exportAllRef.current) exportAllRef.current.click();
+          }}
+        >
+          All data
+        </Menu.Item>
+        <Menu.Item
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (exportRowsRef.current) exportRowsRef.current.click();
+          }}
+        >
+          All current rows
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+};
+
+/**
+ * `TablePseudoExportButton` is hiddens component that responsible for triggering export.
+ *
+ * Use this component on `renderTopToolbarCustomActions()` method
+ */
+export const TablePseudoExportButton: React.FC<
+  TablePseudoExportButtonProps
+> = ({ exportAllRef, exportRowsRef, onExportRows, onExportAll, filenames }) => {
+  const csvExporter = new ExportToCsv(csvOptions(filenames));
+  const exporter = <T extends object>(data: T[]) => {
+    csvExporter.generateCsv(data);
+  };
+
+  const handleEventBubble = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+  return (
+    <Flex display={"none"}>
+      <Button
+        ref={exportAllRef}
+        onClick={(e) => {
+          handleEventBubble(e);
+          onExportAll(exporter);
+        }}
+      />
+      <Button
+        ref={exportRowsRef}
+        onClick={(e) => {
+          handleEventBubble(e);
+          onExportRows(exporter);
+        }}
+      />
+    </Flex>
+  );
+};

--- a/src/ui/Icons/index.tsx
+++ b/src/ui/Icons/index.tsx
@@ -30,6 +30,7 @@ import {
   BsPlus,
   BsCardHeading,
   BsPencilFill,
+  BsSave2,
 } from "react-icons/bs";
 
 export const IconArrowLeft = BsArrowLeft;
@@ -45,6 +46,7 @@ export const IconPeople = BsPeople;
 export const IconX = BsX;
 export const IconPlus = BsPlus;
 export const IconHome = BsHouse;
+export const IconSave = BsSave2;
 export const IconCalendar = BsCalendarWeek;
 export const IconLightBulb = BsLightbulb;
 export const IconBriefcase = BsBriefcase;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3611,6 +3611,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+export-to-csv@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/export-to-csv/-/export-to-csv-0.2.1.tgz#8f997156feebc1cf995096da16341aa0100cce4e"
+  integrity sha512-KTbrd3CAZ0cFceJEZr1e5uiMasabeCpXq1/5uvVxDl53o4jXJHnltasQoj2NkzrxD8hU9kdwjnMhoir/7nNx/A==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"


### PR DESCRIPTION
Currently supported feature
- [x] Export all data
- [x] Export filtered data
- [x] generated link for files from `firestorage`


> **Notes:** 
> Build for **Mantine React Table (MRT)** and using `export-to-csv` for exporting json to csv. 
> Pagination must be handled in the front-end side by `MRT`

---
Room for Improvement :
- Ordering output of CSV
- Sanitize/Copywriting for CSV headers
